### PR TITLE
ctrtransfer: find: NULL is required (2)

### DIFF
--- a/3DS/ctrtransfer.gm9
+++ b/3DS/ctrtransfer.gm9
@@ -31,7 +31,7 @@ allow -a 1:
 if find 1:/rw/sys/SecureInfo_A SECNFO
 elif find 1:/rw/sys/SecureInfo_B SECNFO
 else
-	if find 1:/rw/sys/SecureInfo_C
+	if find 1:/rw/sys/SecureInfo_C NULL
 		cp -n 1:/rw/sys/SecureInfo_C 1:/rw/sys/SecureInfo_A
 	else
 		echo "Your console's SecureInfo is missing.\nAs this is a critical file, the script will\nnot continue without it.\n \nPlease perform data recovery before trying again."


### PR DESCRIPTION
Should we just go straight to digging in essential.exefs instead