### PR TITLE
Add workflow for automatically release 3ds scripts

### DIFF
--- a/.github/workflows/3ds-scripts-release.yml
+++ b/.github/workflows/3ds-scripts-release.yml
@@ -1,0 +1,30 @@
+name: Release 3DS scripts
+
+on:
+  push:
+    branches: [ master ]
+    paths: [ '3DS/*.gm9', '3DS/*.lua' ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: rickstaa/action-create-tag@v1
+        with:
+          tag: 3ds
+          force_push_tag: true
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          name: 3DS Scripts
+          tag_name: 3ds
+          prerelease: true
+          files: |
+            3DS/*.lua
+            3DS/*.gm9


### PR DESCRIPTION
Automatically put 3ds scripts into release so can be linked for download that won't be opened as text on browser

Requires read/write permission for actions